### PR TITLE
Update default semantic commit type to "chore"

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,7 +5,8 @@
         ":pinAllExceptPeerDependencies",
         "github>ExpediaGroup/renovate-config//versions",
         "github>ExpediaGroup/renovate-config//actions",
-        "schedule:earlyMondays"
+        "schedule:earlyMondays",
+        ":semanticCommitType(chore)"
     ],
     "commitMessageExtra": "from v{{currentVersion}} to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
     "commitMessageTopic": "{{#if depType}}{{depType}}{{else}}dependency{{/if}} {{depName}}",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Defaulting to chore makes more semantic sense for dependency upgrades

https://docs.renovatebot.com/presets-default/#semanticprefixchore
